### PR TITLE
Standard Gem Build and Version Isolation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 Gemfile.lock
 .ruby-version
+pkg/*

--- a/Rakefile
+++ b/Rakefile
@@ -1,0 +1,3 @@
+#!/usr/bin/env rake
+
+require 'bundler/gem_tasks'

--- a/quickbase_client.gemspec
+++ b/quickbase_client.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'quickbase_client'
-  s.version       = '1.0.25'
+  s.version       = '1.0.25.intuit'
   s.date          = '2015-03-24'
   s.summary       = "Ruby client for QuickBase"
   s.description   = "A Ruby client for database applications on http://www.quickbase.com"
@@ -11,4 +11,8 @@ Gem::Specification.new do |s|
   s.homepage      =
     'https://rubygems.org/gems/quickbase_client'
   s.license       = 'Eclipse Public License v1.0'
+
+
+  s.add_development_dependency 'bundler', '~> 1.9'
+  s.add_development_dependency 'rake', '~> 10.4'
 end


### PR DESCRIPTION
- adding a Rakefile for builds 
- added Rake and Bundler development dependencies to support standard rake build calls
- modifying version to protect public release collisions
